### PR TITLE
Remove erratic output in ExpmMultiplyParallel.dot

### DIFF
--- a/src/parallel_sparse_tools/expm_multiply_parallel_core/expm_multiply_parallel_core.py
+++ b/src/parallel_sparse_tools/expm_multiply_parallel_core/expm_multiply_parallel_core.py
@@ -234,7 +234,7 @@ class ExpmMultiplyParallel(object):
         else:
             tol = _np.array(self._tol, dtype=mu.real.dtype)
         if v.ndim == 1:
-            print(a.dtype, tol.dtype, mu.dtype, v.dtype, work_array.dtype)
+            # print(a.dtype, tol.dtype, mu.dtype, v.dtype, work_array.dtype)
             _wrapper_expm_multiply(
                 self._A.indptr,
                 self._A.indices,


### PR DESCRIPTION
A dtype test print line in `ExpmMultiplyParallel.dot()` was commented out.

My apologies for this single-line PR. It kept dumping erratic messages in my program, and I spent time locating it.